### PR TITLE
chore: change footer link label to "Documentations" for deploy check

### DIFF
--- a/app/src/components/sections/Footer/index.tsx
+++ b/app/src/components/sections/Footer/index.tsx
@@ -154,7 +154,7 @@ const AppFooter: React.FC = () => {
                 onClick={() => handleFooterLinkClick(APP_CONSTANTS.LINKS.REQUESTLY_DOCS, FOOTER_LINKS.DOCUMENTATION)}
               >
                 <ReadOutlined />
-                Documentation
+                Documentations
               </Text>
               <Dropdown trigger={["click"]} menu={{ items: helpItems }}>
                 <Text>


### PR DESCRIPTION
## Summary
Changes the footer link label from **Documentation** to **Documentations** so the deployment can be visually verified.

This is a temporary verification change — the label can be reverted once deployment is confirmed.

## Changes
- `app/src/components/sections/Footer/index.tsx`: footer link text `Documentation` → `Documentations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)