### PR TITLE
Revert PR #16 (admin-merged without review)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,13 @@ We adhere to the [Requestly code of conduct](./CODE_OF_CONDUCT.md) and by partic
 
 ## Reporting issues
 
-We use [Github issues](https://github.com/requestly/interceptor/issues) to track feature requests and bugs. Please check existing issues before filing anything new. We do our best to respond to the issues as earliest as possible. 
+We use [Github issues](https://github.com/requestly/requestly/issues) to track feature requests and bugs. Please check existing issues before filing anything new. We do our best to respond to the issues as earliest as possible. 
 
 If you would like to contribute a fix, please let us know by leaving a comment on the issue.
 
 ## Pull Requests
 
-Before submitting any pull request (PR), it is recommended that you first log an issue [here](https://github.com/requestly/interceptor/issues) and explain your solution in comments if it is more than a typo fix. It is always a good idea to gather feedback from the team to reduce the number of iterations in code review. 
+Before submitting any pull request (PR), it is recommended that you first log an issue [here](https://github.com/requestly/requestly/issues) and explain your solution in comments if it is more than a typo fix. It is always a good idea to gather feedback from the team to reduce the number of iterations in code review. 
 
 Please note that we have multiple Git repositories. The [Development](#development) section below will help you find the right repo to make changes in. But the issues are still managed centrally in this repository.
 
@@ -33,7 +33,7 @@ All submissions require code review from team. So, please be patient. In case yo
 Requestly is composed of multiple modules:
 - [Browser extension](./browser-extension)
 - [UI application](./app)
-- [Desktop application](https://github.com/requestly/http-interceptor-desktop-app) (Electron-based application for MacOS, Windows)
+- [Desktop application](https://github.com/requestly/requestly-desktop-app) (Electron-based application for MacOS, Windows)
 - [Mobile SDK](https://github.com/requestly/requestly-android-sdk) (to debug mobile apps)
 - [Web SDK](https://github.com/requestly/requestly-web-sdk) (facilitates SessionBook)
 - [Mock Server](https://github.com/requestly/requestly-mock-server)

--- a/app/README.md
+++ b/app/README.md
@@ -19,7 +19,7 @@ npm install
 
 ### Prerequisite - Build and Install Local Extension
 Some features require the Requestly Extension to be installed. Follow the steps below to build and install the extension
-https://github.com/requestly/interceptor/blob/master/browser-extension/mv3/README.md
+https://github.com/requestly/requestly/blob/master/browser-extension/mv3/README.md
 
 ### Build WebApp
 ```

--- a/app/package.json
+++ b/app/package.json
@@ -6,11 +6,11 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/requestly/interceptor.git",
+    "url": "git+https://github.com/requestly/requestly.git",
     "directory": "app"
   },
   "bugs": {
-    "url": "https://github.com/requestly/interceptor/issues"
+    "url": "https://github.com/requestly/requestly/issues"
   },
   "author": {
     "name": "Requestly",

--- a/app/src/config/constants/sub/links.js
+++ b/app/src/config/constants/sub/links.js
@@ -168,7 +168,7 @@ const LINKS = {
 
   API_CLIENT_LOCAL_FIRST_ANNOUNCEMENT: "https://github.com/requestly/requestly/issues/2629",
 
-  REQUESTLY_GITHUB: "https://github.com/requestly/interceptor",
+  REQUESTLY_GITHUB: "https://github.com/requestly/requestly",
 
   OAUTH_REDIRECT_URL: `${process.env.VITE_BACKEND_BASE_URL}/oauth/authorize`,
 

--- a/app/src/layouts/DashboardLayout/MenuHeader/MenuHeader.tsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/MenuHeader.tsx
@@ -32,7 +32,7 @@ export const MenuHeader = () => {
     return (
       <span className="github-star-button" onClick={() => trackHeaderClicked("github_star_button")}>
         <GitHubButton
-          href="https://github.com/requestly/interceptor"
+          href="https://github.com/requestly/requestly"
           data-color-scheme="dark_dimmed"
           data-text="Star"
           data-show-count="true"

--- a/app/src/lib/design-system-v2/README.md
+++ b/app/src/lib/design-system-v2/README.md
@@ -5,7 +5,7 @@
 - Install this extension https://marketplace.visualstudio.com/items?itemName=vunguyentuan.vscode-css-variables
 
 ## Adding Token
-- Update `theme.css`: After adding color tokens, please update the [theme.css](https://github.com/requestly/interceptor/blob/master/app/src/lib/design-system-v2/helpers/theme.css) file by uncommenting these lines https://github.com/requestly/interceptor/blob/09c6eaf3a1126552ecf5e4c4aced423e005d1272/app/src/lib/design-system-v2/helpers/ThemeProvider.tsx#L42-L47
+- Update `theme.css`: After adding color tokens, please update the [theme.css](https://github.com/requestly/requestly/blob/master/app/src/lib/design-system-v2/helpers/theme.css) file by uncommenting these lines https://github.com/requestly/requestly/blob/09c6eaf3a1126552ecf5e4c4aced423e005d1272/app/src/lib/design-system-v2/helpers/ThemeProvider.tsx#L42-L47
 
 ## Usage
 

--- a/app/src/src-SessionBear/components/MenuHeader/index.js
+++ b/app/src/src-SessionBear/components/MenuHeader/index.js
@@ -60,7 +60,7 @@ const MenuHeader = () => {
                   <GitHubButton
                     style={{ display: "flex" }}
                     className="github-star-button"
-                    href="https://github.com/requestly/interceptor"
+                    href="https://github.com/requestly/requestly"
                     data-color-scheme="dark_dimmed"
                     data-text="Star"
                     data-show-count="true"

--- a/browser-extension/common/package.json
+++ b/browser-extension/common/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/requestly/interceptor.git",
+    "url": "git+https://github.com/requestly/requestly.git",
     "directory": "browser-extension/common"
   },
   "author": {
@@ -20,7 +20,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
-    "url": "https://github.com/requestly/interceptor/issues"
+    "url": "https://github.com/requestly/requestly/issues"
   },
   "scripts": {
     "preinstall": "sh ./scripts/build-analytics-vendor.sh",

--- a/browser-extension/config/package.json
+++ b/browser-extension/config/package.json
@@ -6,11 +6,11 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/requestly/interceptor.git",
+    "url": "git+https://github.com/requestly/requestly.git",
     "directory": "browser-extension/config"
   },
   "bugs": {
-    "url": "https://github.com/requestly/interceptor/issues"
+    "url": "https://github.com/requestly/requestly/issues"
   },
   "author": {
     "name": "Requestly",

--- a/browser-extension/mv3/package.json
+++ b/browser-extension/mv3/package.json
@@ -6,11 +6,11 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/requestly/interceptor.git",
+    "url": "git+https://github.com/requestly/requestly.git",
     "directory": "browser-extension/mv3"
   },
   "bugs": {
-    "url": "https://github.com/requestly/interceptor/issues"
+    "url": "https://github.com/requestly/requestly/issues"
   },
   "author": {
     "name": "Requestly",

--- a/browser-extension/sessionbear/package.json
+++ b/browser-extension/sessionbear/package.json
@@ -6,11 +6,11 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/requestly/interceptor.git",
+    "url": "git+https://github.com/requestly/requestly.git",
     "directory": "browser-extension/mv3"
   },
   "bugs": {
-    "url": "https://github.com/requestly/interceptor/issues"
+    "url": "https://github.com/requestly/requestly/issues"
   },
   "author": {
     "name": "Requestly",

--- a/documentation/docs.json
+++ b/documentation/docs.json
@@ -264,7 +264,7 @@
     "socials": {
       "x": "https://x.com/requestlyio",
       "linkedin": "https://linkedin.com/company/requestly",
-      "github": "https://github.com/requestly/interceptor",
+      "github": "https://github.com/requestly/requestly",
       "youtube": "https://youtube.com/@requestly"
     },
     "links": [
@@ -306,7 +306,7 @@
           },
           {
             "label": "GitHub",
-            "href": "https://github.com/requestly/interceptor"
+            "href": "https://github.com/requestly/requestly"
           }
         ]
       },

--- a/documentation/guides/community-content/README.md
+++ b/documentation/guides/community-content/README.md
@@ -125,7 +125,7 @@ git push origin your-branch-name
 ## Questions?
 
 - **Documentation**: [docs.requestly.com](https://docs.requestly.com)
-- **GitHub Discussions**: [github.com/requestly/interceptor/discussions](https://github.com/requestly/interceptor/discussions)
+- **GitHub Discussions**: [github.com/requestly/requestly/discussions](https://github.com/requestly/requestly/discussions)
 - **Discord**: [Join our Discord community](https://rqst.ly/join-community)
 - **Email**: contact@requestly.io
 

--- a/documentation/interceptor/desktop-app/android-simulator-interception.mdx
+++ b/documentation/interceptor/desktop-app/android-simulator-interception.mdx
@@ -208,7 +208,7 @@ adb shell settings put global http_proxy :0
 
 Here's the code that makes this happen in a single click
 
-[**https://github.com/requestly/http-interceptor-desktop-app/blob/fb1f321a3d2431cfcd9d95d1396bcd39820a4ec9/src/renderer/actions/apps/mobile/android.js#L63-L74**](https://github.com/requestly/http-interceptor-desktop-app/blob/fb1f321a3d2431cfcd9d95d1396bcd39820a4ec9/src/renderer/actions/apps/mobile/android.js#L63-L74)
+[**https://github.com/requestly/requestly-desktop-app/blob/fb1f321a3d2431cfcd9d95d1396bcd39820a4ec9/src/renderer/actions/apps/mobile/android.js#L63-L74**](https://github.com/requestly/requestly-desktop-app/blob/fb1f321a3d2431cfcd9d95d1396bcd39820a4ec9/src/renderer/actions/apps/mobile/android.js#L63-L74)
 
 1. Searches for online ADB devices
 

--- a/documentation/troubleshoot/http-interceptor/troubleshooting-untrusted-ssl-certificate.mdx
+++ b/documentation/troubleshoot/http-interceptor/troubleshooting-untrusted-ssl-certificate.mdx
@@ -16,7 +16,7 @@ Before following the troubleshooting steps, make sure you have done both of thes
 
 Safari connection might not work with VPN because of the system-wide proxy setup. **If you are using Requestly Interceptor with VPN, you need to disable VPN first, then launch Safari from** `Connected Apps` **and then restart your VPN.**
 
-> ***In our internal testing we found that TunnelBlick and the OpenVPN work well with Requestly Interceptor system wide proxy running. In case you face issues working with these or any other VPN client, feel free to reach out at*** [***contact@requestly.io***](mailto:contact@requestly.io) ***or*** [***raise an issue***](https://github.com/requestly/interceptor/issues/new?assignees=\&labels=bug\&labels=vpn\&projects=\&template=bug-report.yml\&title=bug%3A+)
+> ***In our internal testing we found that TunnelBlick and the OpenVPN work well with Requestly Interceptor system wide proxy running. In case you face issues working with these or any other VPN client, feel free to reach out at*** [***contact@requestly.io***](mailto:contact@requestly.io) ***or*** [***raise an issue***](https://github.com/requestly/requestly/issues/new?assignees=\&labels=bug\&labels=vpn\&projects=\&template=bug-report.yml\&title=bug%3A+)
 
 ### **Verify Proxy**
 

--- a/documentation/troubleshoot/http-rules/error-on-saving-rule.mdx
+++ b/documentation/troubleshoot/http-rules/error-on-saving-rule.mdx
@@ -41,4 +41,4 @@ If your error does not fall under the above categories, or you're unsure how to 
 
 * Note the **error message** from the console.
 
-* Contact our support team or file an issue with details on [GitHub](https://github.com/requestly/interceptor/issues).
+* Contact our support team or file an issue with details on [GitHub](https://github.com/requestly/requestly/issues).

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/requestly/interceptor.git"
+    "url": "git+https://github.com/requestly/requestly.git"
   },
   "author": {
     "name": "Requestly",
@@ -31,7 +31,7 @@
     "npm": ">=8.0.0"
   },
   "bugs": {
-    "url": "https://github.com/requestly/interceptor/issues"
+    "url": "https://github.com/requestly/requestly/issues"
   },
   "homepage": "https://requestly.com",
   "devDependencies": {


### PR DESCRIPTION
## Why this revert

PR #16 was merged via `gh pr merge --admin --squash`, bypassing the master ruleset's required-review gate. Restoring proper review process.

## Path forward

1. **Approve this revert** → URL refs go back to pointing at `requestly/requestly`. Re-open original change as a fresh PR for proper review.
2. **Close this revert** → Existing change stays.

## What was in PR #16
- 17 files updated: package.json (5), CONTRIBUTING.md, links.js, app/src/* header constants, documentation .mdx
- Bare `requestly/requestly` repo refs → `requestly/interceptor`
- `requestly/requestly-desktop-app` → `requestly/http-interceptor-desktop-app`
- Preserved: `/issues/N`, `/pull/N`, README banner, Issue Forms, npm scoped names

Original PR: #16
Admin-merge commit: `edefe2547e22`

🤖 Generated with [Claude Code](https://claude.com/claude-code)