### PR TITLE
chore(compat): bump Windows desktop floor to 26.6.8

### DIFF
--- a/app/src/config/constants/compatibility.js
+++ b/app/src/config/constants/compatibility.js
@@ -184,7 +184,7 @@ export const FEATURE_COMPATIBLE_VERSION = {
   [FEATURES.COMPATIBLE_DESKTOP_APP]: {
     [GLOBAL_CONSTANTS.APP_MODES.DESKTOP]: {
       macOS: "25.5.20",
-      Windows: "25.6.25",
+      Windows: "26.6.8",
       Linux: "1.4.20",
     },
     [GLOBAL_CONSTANTS.APP_MODES.EXTENSION]: null,
@@ -193,7 +193,7 @@ export const FEATURE_COMPATIBLE_VERSION = {
   [FEATURES.NON_BREAKING_DESKTOP_APP]: {
     [GLOBAL_CONSTANTS.APP_MODES.DESKTOP]: {
       macOS: "25.5.20",
-      Windows: "25.6.25",
+      Windows: "26.6.8",
       Linux: "1.4.20",
     },
     [GLOBAL_CONSTANTS.APP_MODES.EXTENSION]: null,


### PR DESCRIPTION
## Summary

Bumps the **Windows** floor in `app/src/config/constants/compatibility.js` from \`25.6.25\` → \`26.6.8\` in both gate entries:

- \`FEATURES.COMPATIBLE_DESKTOP_APP\` (soft floor — \"restart to install update\" dialog after an update is downloaded)
- \`FEATURES.NON_BREAKING_DESKTOP_APP\` (hard floor — \`MandatoryUpdateScreen\` immediately on launch, CTA → manual redownload)

macOS (\`25.5.20\`) and Linux (\`1.4.20\`) floors are unchanged.

## Why

26.6.8 is the version currently shipping from \`requestly/http-interceptor-desktop-app\` master (PRs #339 + #342 merged today). It's the first Windows build signed via the new Google Cloud KMS flow. Any user still on an older Windows build is signed under the previous trust chain and should be force-migrated to the new one.

## Effect on Windows users

| Installed version | What they see |
|---|---|
| \`< 26.6.8\` | \`MandatoryUpdateScreen\` on launch — non-dismissible — CTA opens \`requestly.com/desktop\` for manual redownload |
| \`>= 26.6.8\` | No gate |

## Files changed

```
app/src/config/constants/compatibility.js   +2 / -2
```

## Notes

- Single-file change, 4 lines of YYM.D version-string edits — no logic change.
- Both gate entries (soft + hard) have historically been kept in lockstep per platform; bumped both to maintain that invariant.
- Once this merges and rolls out to \`app.requestly.com\`, Windows users below \`26.6.8\` will be blocked the next time they open the desktop app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)