### PR TITLE
fix: point in-app GitHub Issues link to the interceptor repo

### DIFF
--- a/app/src/config/constants/sub/links.js
+++ b/app/src/config/constants/sub/links.js
@@ -115,7 +115,7 @@ const LINKS = {
   /** SUPPORT */
 
   //Github Issues
-  REQUESTLY_GITHUB_ISSUES: "https://github.com/requestly/customer-support/issues",
+  REQUESTLY_GITHUB_ISSUES: "https://github.com/requestly/interceptor/issues",
   FEEDBACK: "https://feedback.requestly.io/",
 
   /** EXTENSIONS */


### PR DESCRIPTION
## What

Repoints the in-app GitHub Issues link (`REQUESTLY_GITHUB_ISSUES`) from `requestly/customer-support/issues` → `requestly/interceptor/issues`.

## Why

`requestly/customer-support` now **301-redirects to `requestly/requestly`**, which post-restructure is the **Requestly API Client** community hub ("bugs, feature requests, and roadmap — the privacy-first Postman alternative"). This app ships the **HTTP Interceptor**, so every in-app "report a bug / request a feature" entry point was landing Interceptor users on the **API Client** repo.

Surfaced from **Help → "Bugs & feature request"** on `app.requestly.io/rules`.

## Scope

One constant change. It fans out to all six consumers:

- Footer "Bugs & feature request" — `components/sections/Footer`
- Command bar action — `components/misc/CommandBar/config`
- Support panel — `components/misc/SupportPanel`
- Rule Builder Help — "Request a feature" + "Ask GitHub community"
- `utils/RedirectionUtils` open/navigate helper

`app/package.json` `bugs.url` was already `requestly/interceptor/issues` — left untouched.

## Out of scope (intentionally not changed)

- Specific issue permalinks (`.../issues/<N>`) in changelogs, rule banners, and the API Client migration block — these legitimately stay on `requestly/requestly`.
- Pre-existing `// TODO: update link` on the "Ask GitHub community" help item (likely should point to GitHub Discussions, not Issues) — separate concern; this PR at least routes it to the correct repo.

## Verification

- `git diff`: single-line change, string → string, no syntax change.
- All six call sites consume the constant identically (grep-confirmed).
- `requestly/interceptor` exists with Issues enabled.
- ESM syntax check on the edited file passes (`node --check`).

> Note: a full `vite build` would require a fresh `yarn install` that mostly exercises unrelated infra for a string-constant swap, so it was not run here. Happy to add it if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
