### PR TITLE
Keep collection description edit action separate from description text

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionOverview/CollectionOverview.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionOverview/CollectionOverview.tsx
@@ -2,7 +2,7 @@ import type React from "react";
 import { useCallback, useMemo, useState } from "react";
 import * as Sentry from "@sentry/react";
 import { InlineInput } from "componentsV2/InlineInput/InlineInput";
-import { Input, notification, Tabs } from "antd";
+import { Button, Input, notification, Tabs } from "antd";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
@@ -163,18 +163,16 @@ export const CollectionOverview: React.FC<CollectionOverviewProps> = ({ collecti
               ]}
             />
           ) : (
-            <div
-              className="collection-overview-description-markdown"
-              onClick={() => {
-                if (!isValidPermission) {
-                  return;
-                }
-
-                setShowEditor(true);
-              }}
-            >
-              {markdown}
-            </div>
+            <>
+              {isValidPermission ? (
+                <div className="collection-overview-description-actions">
+                  <Button type="link" size="small" onClick={() => setShowEditor(true)}>
+                    Edit Description
+                  </Button>
+                </div>
+              ) : null}
+              <div className="collection-overview-description-markdown">{markdown}</div>
+            </>
           )}
         </div>
       </div>

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionOverview/collectionOverview.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionOverview/collectionOverview.scss
@@ -47,12 +47,22 @@
       background: var(--requestly-color-surface-0);
     }
 
+    &-actions {
+      display: flex;
+      justify-content: flex-end;
+      margin-bottom: 4px;
+
+      .ant-btn-link {
+        padding: 0;
+        height: auto;
+      }
+    }
+
     &-markdown {
       padding: 8px;
       border-radius: 8px;
 
       &:hover {
-        cursor: text;
         background: var(--requestly-color-surface-0);
       }
     }


### PR DESCRIPTION
## Summary
- separate the collection description edit action from the rendered markdown body
- keep the rendered description as read-only content while using a dedicated Edit Description button
- preserve the existing markdown editor and preview behavior once editing starts

## Verification
- git diff --check

Closes requestly/interceptor#34