### PR TITLE
fix(profile): resolve avatar provider-first, else live Gravatar

### DIFF
--- a/app/src/features/settings/components/Profile/ManageAccount.js
+++ b/app/src/features/settings/components/Profile/ManageAccount.js
@@ -5,6 +5,7 @@ import { Button as AntButton } from "antd";
 import UserInfo from "./UserInfo";
 //UTILS
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
+import { getUserAvatarUrl } from "utils/ImageUtils";
 import { redirectToDeleteAccount, redirectToSignDPA } from "../../../../utils/RedirectionUtils";
 // ACTIONS
 import { handleForgotPasswordButtonOnClick } from "features/onboarding/components/auth/components/Form/actions";
@@ -21,9 +22,7 @@ const ManageAccount = () => {
 
   //Component State
   const [isChangePasswordLoading, setIsChangePasswordLoading] = useState(false);
-  // Fallback image
-  const defaultImageSrc = "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y";
-  let userImageSrc = user.details.profile.photoURL ? user.details.profile.photoURL : defaultImageSrc;
+  let userImageSrc = getUserAvatarUrl(user.details.profile.email, user.details.profile.photoURL);
 
   const userDisplayName = user.details.profile.displayName ? user.details.profile.displayName : "User";
 

--- a/app/src/layouts/DashboardLayout/MenuHeader/HeaderUser.jsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/HeaderUser.jsx
@@ -16,7 +16,7 @@ import {
 import { handleLogoutButtonOnClick } from "features/onboarding/components/auth/components/Form/actions";
 import APP_CONSTANTS from "config/constants";
 import { SOURCE } from "modules/analytics/events/common/constants";
-import { parseGravatarImage } from "utils/Misc";
+import { getUserAvatarUrl } from "utils/ImageUtils";
 import { trackHeaderClicked } from "modules/analytics/events/common/onboarding/header";
 import { trackUpgradeClicked } from "modules/analytics/events/misc/monetizationExperiment";
 import { getAppFlavour } from "utils/AppUtils";
@@ -43,7 +43,9 @@ export default function HeaderUser() {
 
   const userName = user.loggedIn ? user?.details?.profile?.displayName ?? "User" : null;
   const userPhoto =
-    user.loggedIn && user?.details?.profile?.photoURL ? parseGravatarImage(user.details.profile.photoURL) : null;
+    user.loggedIn && user?.details?.profile
+      ? getUserAvatarUrl(user.details.profile.email, user.details.profile.photoURL)
+      : null;
   const userEmail = user?.details?.profile?.email;
   const planDetails = user?.details?.planDetails;
 

--- a/app/src/utils/ImageUtils.js
+++ b/app/src/utils/ImageUtils.js
@@ -16,17 +16,32 @@ export const generateGravatarURL = (email = "sagar@requestly.io") => {
 };
 
 /**
+ * True when `url`'s host is Gravatar. Parses the URL and matches on the hostname
+ * rather than a substring — `url.includes("gravatar.com")` would also match
+ * unrelated hosts such as `gravatar.com.evil.com` or `host/path?ref=gravatar.com`.
+ * Unparseable values return false (treated as "not a Gravatar URL").
+ */
+const isGravatarUrl = (url) => {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === "gravatar.com" || host.endsWith(".gravatar.com");
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Resolves the avatar to display for a user.
  *
  * Precedence: the auth provider's photo (e.g. Google) when we have a real one,
  * otherwise a Gravatar resolved live from the current login email — so changes a
  * user makes on Gravatar are reflected here. For email/password accounts we persist
- * a synthetic gravatar.com URL as `photoURL`, so any gravatar.com value is treated
+ * a synthetic gravatar.com URL as `photoURL`, so any Gravatar-hosted value is treated
  * as "no provider photo" and re-resolved live from the email. `d=mp` is Gravatar's
  * deterministic fallback, shown when the email has no Gravatar image.
  */
 export const getUserAvatarUrl = (email = "", providerPhotoURL = "") => {
-  if (providerPhotoURL && !providerPhotoURL.includes("gravatar.com")) {
+  if (providerPhotoURL && !isGravatarUrl(providerPhotoURL)) {
     return providerPhotoURL;
   }
   return `https://www.gravatar.com/avatar/${md5(email)}?s=200&d=mp`;

--- a/app/src/utils/ImageUtils.js
+++ b/app/src/utils/ImageUtils.js
@@ -14,3 +14,20 @@ export const getRandomAvatar = () => {
 export const generateGravatarURL = (email = "sagar@requestly.io") => {
   return `https://www.gravatar.com/avatar/${md5(email)}?s=200&d=${getRandomAvatar()}`;
 };
+
+/**
+ * Resolves the avatar to display for a user.
+ *
+ * Precedence: the auth provider's photo (e.g. Google) when we have a real one,
+ * otherwise a Gravatar resolved live from the current login email — so changes a
+ * user makes on Gravatar are reflected here. For email/password accounts we persist
+ * a synthetic gravatar.com URL as `photoURL`, so any gravatar.com value is treated
+ * as "no provider photo" and re-resolved live from the email. `d=mp` is Gravatar's
+ * deterministic fallback, shown when the email has no Gravatar image.
+ */
+export const getUserAvatarUrl = (email = "", providerPhotoURL = "") => {
+  if (providerPhotoURL && !providerPhotoURL.includes("gravatar.com")) {
+    return providerPhotoURL;
+  }
+  return `https://www.gravatar.com/avatar/${md5(email)}?s=200&d=mp`;
+};


### PR DESCRIPTION
## Problem

A user reported that updating their avatar on Gravatar never reflected in the app (FD ticket #1691141 / RQ-4032).

Root cause: the signed-in user's avatar was read from a **one-time `photoURL` snapshot**, not resolved live:

- **Google / SSO accounts** → `photoURL` is the Google photo; Gravatar is never consulted.
- **Email/password accounts** → `photoURL` is either a synthetic `gravatar.com/avatar/md5(email)` written once at signup, or — when missing — the all-zeros dummy `avatar/00000000000000000000000000000000?d=mp&f=y`, which forces Gravatar's mystery-person regardless of the user's real Gravatar.

So Gravatar updates couldn't surface for affected users.

## Fix

New `getUserAvatarUrl(email, providerPhotoURL)` in `app/src/utils/ImageUtils.js`:

- **Provider photo wins** when present (e.g. Google) → Gmail/SSO users keep their photo, unchanged.
- **Otherwise** resolve Gravatar **live from the current login email** → users who set/update a Gravatar on their login email now see it, and the broken all-zeros snapshot is re-pointed to the real `md5(email)` hash. `d=mp` is the deterministic fallback when no Gravatar exists.

Wired into the two surfaces that render the **current user's own** avatar:

- `app/src/layouts/DashboardLayout/MenuHeader/HeaderUser.jsx` (header dropdown)
- `app/src/features/settings/components/Profile/ManageAccount.js` (profile page)

`parseGravatarImage` is left intact — still used by `OrgNotificationBanner`.

## Behavior

| Account | Result |
| --- | --- |
| Google / SSO | Google photo (unchanged) |
| Email/password with a Gravatar | their Gravatar, reflecting updates |
| No Gravatar / no provider photo | `d=mp` silhouette |

Caveats (inherent to Gravatar): keyed on the login-email hash, and image refresh is subject to browser/Gravatar cache.

## Out of scope

Other surfaces that render *other* users'/members' avatars (`OrgMembersTable`, `OrgNotificationBanner`, `JoinWorkspaceCard`) still use the prior pattern — a follow-up could apply the same resolution there if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
