### PR TITLE
fix(security): thread relay token + trusted origin to session recorder (RQ-3095, RQ-3096)

### DIFF
--- a/browser-extension/common/src/types.ts
+++ b/browser-extension/common/src/types.ts
@@ -113,6 +113,11 @@ export interface SessionRecordingConfig {
   widgetPosition?: { top?: number; bottom?: number; left?: number; right?: number };
   recordingStartTime?: number;
   previousSession?: any;
+  // Per-recording relay auth (RQ-3095 / RQ-3096): a shared secret token and the
+  // top-frame origin, threaded to every frame so cross-origin iframe relay is
+  // authenticated (token) and not broadcast to untrusted frames (trustedOrigin).
+  relayToken?: string;
+  trustedOrigin?: string;
 }
 
 export interface RulePair {

--- a/browser-extension/mv3/src/content-scripts/common/sessionRecorder.ts
+++ b/browser-extension/mv3/src/content-scripts/common/sessionRecorder.ts
@@ -81,6 +81,8 @@ const sendStartRecordingEvent = async (sessionRecordingConfig: SessionRecordingC
     showWidget,
     widgetPosition,
     previousSession,
+    relayToken,
+    trustedOrigin,
   } = sessionRecordingConfig;
 
   const isIFrame = isIframe();
@@ -95,6 +97,10 @@ const sendStartRecordingEvent = async (sessionRecordingConfig: SessionRecordingC
     maxDuration: (sessionRecordingConfig.maxDuration || 5) * 60 * 1000, // minutes -> milliseconds
     previousSession: !isIFrame ? previousSession : null,
     localStorage: true,
+    // Relay auth: top frame uses relayToken to validate incoming events; iframes use
+    // both to authenticate and to target the relay at the top origin (RQ-3095/RQ-3096).
+    relayToken,
+    trustedOrigin,
   });
 
   sessionRecorderState.isExplicitRecording = explicit;

--- a/browser-extension/mv3/src/service-worker/services/sessionRecording.ts
+++ b/browser-extension/mv3/src/service-worker/services/sessionRecording.ts
@@ -10,6 +10,24 @@ import { isExtensionEnabled } from "../../utils";
 
 const CONFIG_STORAGE_KEY = "sessionRecordingConfig";
 
+const getTopFrameOrigin = (url?: string): string | undefined => {
+  try {
+    return url ? new URL(url).origin : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+// Ensures the per-recording relay auth fields (RQ-3095 / RQ-3096) are present and
+// stable across every frame of the tab: one random token, generated once and reused
+// (so top and iframes share it), plus the top-frame origin used as the relay
+// postMessage targetOrigin. Both are broadcast to all frames via startRecording.
+const withRelayAuth = (data: Record<string, any>, topUrl?: string): Record<string, any> => ({
+  ...data,
+  relayToken: data.relayToken ?? crypto.randomUUID(),
+  trustedOrigin: getTopFrameOrigin(topUrl),
+});
+
 const getSessionRecordingConfig = async (url: string): Promise<SessionRecordingConfig> => {
   const sessionRecordingConfig = await getRecord<SessionRecordingConfig>(CONFIG_STORAGE_KEY);
 
@@ -100,7 +118,7 @@ export const startRecordingExplicitly = async (tab: chrome.tabs.Tab, showWidget:
     return;
   }
 
-  const sessionRecordingData = { explicit: true, showWidget };
+  const sessionRecordingData = withRelayAuth({ explicit: true, showWidget }, tab.url);
   tabService.setData(tab.id, TAB_SERVICE_DATA.SESSION_RECORDING, sessionRecordingData);
 
   startRecording(tab.id, sessionRecordingData);
@@ -145,6 +163,11 @@ export const handleSessionRecordingOnClientPageLoad = async (tab: chrome.tabs.Ta
   }
 
   if (sessionRecordingData) {
+    // Attach/keep the stable relay token + top origin before broadcasting so every
+    // frame (top and iframes, including ones that load later) receives the same values.
+    sessionRecordingData = withRelayAuth(sessionRecordingData, tab.url);
+    tabService.setData(tab.id, TAB_SERVICE_DATA.SESSION_RECORDING, sessionRecordingData);
+
     startRecording(tab.id, sessionRecordingData).then(() => {
       tabService.setData(tab.id, TAB_SERVICE_DATA.SESSION_RECORDING, {
         ...sessionRecordingData,


### PR DESCRIPTION
## What & why

Wires the session-recorder relay auth (RQ-3095, RQ-3096) end to end. The service worker mints one stable `relayToken` per recording plus the top-frame origin, and the content script forwards both into the `SessionRecorder` SDK options. Result: cross-origin iframe relay is authenticated (token) and no longer broadcast to untrusted frames (`trustedOrigin`).

## Changes

- `browser-extension/common/src/types.ts` — add optional `relayToken` / `trustedOrigin` to `SessionRecordingConfig`.
- `browser-extension/mv3/src/service-worker/services/sessionRecording.ts` — `withRelayAuth()` mints/keeps a stable token + top origin; applied at both `startRecording` broadcast sites (broadcast reaches every frame, so top and iframes share the same token).
- `browser-extension/mv3/src/content-scripts/common/sessionRecorder.ts` — forward both fields into the SDK options.

## Testing

- Built the extension with the updated SDK and verified cross-page recording is unaffected — A/B compared against a stock build, identical behavior.
- Relay auth verified via the SDK's two-origin harness.

## Dependency / release ordering ⚠️

Depends on the paired SDK change: requestly/requestly-web-sdk#18.

Before release: publish the new `@requestly/web-sdk` version and bump the pin in `browser-extension/mv3/package.json` (currently `0.15.1`). The release runs a clean `npm install`, which would otherwise pull the old SDK without relay-auth support and silently ship without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
