### PR TITLE
fix(sw): pin CSP/initiator handlers to sender origin (RQ-3050)

### DIFF
--- a/browser-extension/mv3/src/service-worker/services/messageHandler/listener.ts
+++ b/browser-extension/mv3/src/service-worker/services/messageHandler/listener.ts
@@ -44,6 +44,30 @@ import {
   reopenNetworkRecordingPanel,
 } from "../networkRecording";
 
+/**
+ * Derives the true origin of a message sender from browser-populated fields
+ * (`sender.origin`, falling back to parsing `sender.url`). Chrome sets these from the
+ * actual sending frame, so — unlike anything inside the message payload — a web page
+ * cannot forge them. Returns `undefined` when no origin can be determined; an opaque
+ * (sandboxed) frame legitimately serializes to the string "null".
+ *
+ * Used to pin caller-supplied `requestDetails.initiator` to the real sender origin so a
+ * page cannot claim another origin (RQ-3050 and its onBeforeAjaxRequest sibling).
+ */
+const getTrustedSenderOrigin = (sender: chrome.runtime.MessageSender): string | undefined => {
+  if (sender.origin) {
+    return sender.origin;
+  }
+  if (!sender.url) {
+    return undefined;
+  }
+  try {
+    return new URL(sender.url).origin;
+  } catch {
+    return undefined;
+  }
+};
+
 export const initExternalMessageListener = () => {
   chrome.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {
     switch (message.action) {
@@ -197,12 +221,39 @@ export const initMessageHandler = () => {
         break;
 
       case EXTENSION_MESSAGES.ON_BEFORE_AJAX_REQUEST:
-        requestProcessor.onBeforeAJAXRequest(sender.tab.id, message.requestDetails).then(sendResponse);
+        // Security (RQ-3050 sibling): handleInitiatorDomainFunction stamps requestDetails.initiator
+        // into headers for rules that use rq_request_initiator_origin(). This message arrives over
+        // the same forgeable page channel, so pin initiator to the unforgeable sender origin — a page
+        // must not be able to claim another origin. requestDetails.url / requestHeaders stay as-is (the
+        // AJAX target is legitimately cross-origin, and forwardHeadersOnRedirect scopes its own rule to
+        // the user's redirect destination). For real traffic initiator === sender origin, so this is a
+        // no-op; an opaque frame's origin is "null", which is also its truthful value.
+        requestProcessor
+          .onBeforeAJAXRequest(sender.tab.id, {
+            ...message.requestDetails,
+            initiator: getTrustedSenderOrigin(sender),
+          })
+          .then(sendResponse);
         return true;
 
-      case EXTENSION_MESSAGES.ON_ERROR_OCCURRED:
-        requestProcessor.onErrorOccurred(sender.tab.id, message.requestDetails).then(sendResponse);
+      case EXTENSION_MESSAGES.ON_ERROR_OCCURRED: {
+        // Security (RQ-3050): handleCSPError strips the Content-Security-Policy header for
+        // requestDetails.initiator. This message is relayed from the page's MAIN world, where
+        // the caller-supplied initiator is forgeable, so a page could arm a CSP-removal rule for
+        // an arbitrary third-party origin. Pin the target to the browser-provided sender origin
+        // (unforgeable) so a page can only ever affect its own origin. The legitimate emitter
+        // already sends initiator === location.origin and posts same-frame, so this is a no-op
+        // for real traffic — keep the emitter same-frame (never window.top) or this breaks.
+        const trustedOrigin = getTrustedSenderOrigin(sender);
+        if (!sender.tab?.id || !trustedOrigin || trustedOrigin === "null") {
+          sendResponse();
+          return true;
+        }
+        requestProcessor
+          .onErrorOccurred(sender.tab.id, { ...message.requestDetails, initiator: trustedOrigin })
+          .then(sendResponse);
         return true;
+      }
 
       case EXTENSION_MESSAGES.TEST_RULE_ON_URL:
         launchUrlAndStartRuleTesting(message, sender.tab.id);


### PR DESCRIPTION
## Summary

Two message handlers in the MV3 service worker derived a target origin from the **caller-supplied** `requestDetails.initiator`. That message is relayed from the page's MAIN world over the forgeable `source: "requestly:client"` channel, so any web page could set `initiator` to an arbitrary origin. Both are now pinned to the browser-provided **sender origin**, which a page cannot forge.

## What was vulnerable

- **`onErrorOccurred` → `handleCSPError`** (RQ-3050): removes a site's `Content-Security-Policy` response header for `requestDetails.initiator`. A forged initiator let a page arm a tab-scoped rule that strips a **third-party origin's CSP**, weakening its XSS/clickjacking defenses.
- **`onBeforeAjaxRequest` → `handleInitiatorDomainFunction`** (sibling, found in review): stamps `requestDetails.initiator` into headers for rules using `rq_request_initiator_origin()`. A forged initiator let a page **spoof the origin value** that feature is meant to certify (conditional on the victim having a matching enabled Headers rule). Lower severity — no CSP removal, rule-gated, tab-scoped — but the same root cause.

## The fix

- New shared helper `getTrustedSenderOrigin(sender)` derives the origin from `sender.origin` (falling back to a guarded `new URL(sender.url).origin`) — browser-populated, unforgeable — returning `undefined`/`"null"` for indeterminate/opaque frames.
- `onErrorOccurred`: pins the CSP target to the sender origin; skips when there is no trusted origin (fail-closed).
- `onBeforeAjaxRequest`: overwrites `initiator` with the sender origin before processing. `url` / `requestHeaders` remain caller-supplied (the AJAX target is legitimately cross-origin).

## Why this is safe (no behavior change for real traffic)

The legitimate emitter (`ajaxRequestInterceptor`) always sends `initiator === location.origin` and posts **same-frame**, so `sender.origin` equals the value it already sends — the pin is a **no-op for genuine traffic** and only discards forged cross-origin values. A per-frame comment documents the "same-frame emitter" invariant.

## Testing

- Built (`npm run build:current`, clean) and loaded unpacked; both pins verified in `dist/serviceWorker.js`.
- **CSP (RQ-3050):** Insert-Script rule still injects on a strict-CSP site (`github.com`) and produces a CSP-removal rule for its **own** origin; a forged `onErrorOccurred` with a cross-origin `initiator` no longer creates a rule for that origin.
- **Initiator header:** `rq_request_initiator_origin()` still stamps the true page origin (incl. iframe / cross-origin XHR variants); a forged `initiator` is overridden with the real sender origin.

## Notes / follow-ups (not in this PR)

- **RQ-3058** (`cacheSharedState`, same file) is a related, still-open issue — will be handled separately after its own review.
- The `requestly-automation` package vendors a built copy of this extension; it will be **re-vendored after this PR merges**.
- Branch was cut from a `master` that is a few commits behind `origin/master`; rebase before merge if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)