### PR TITLE
fix(billing): derive team membership from billing doc, not fetched profiles (RQ-5382)

### DIFF
--- a/app/src/features/settings/components/BillingTeam/components/BillingDetails/index.tsx
+++ b/app/src/features/settings/components/BillingTeam/components/BillingDetails/index.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
 import { useParams, useSearchParams } from "react-router-dom";
 import { useCheckCurrentTeamAccess } from "../../hooks/useCheckCurrentTeamAccess";
-import { getAvailableBillingTeams, getBillingTeamMemberById } from "store/features/billing/selectors";
+import { getAvailableBillingTeams } from "store/features/billing/selectors";
 import { Result } from "antd";
 import { MyBillingTeamDetails } from "./MyBillingTeamDetails";
 import { OtherBillingTeamDetails } from "./OtherBillingTeamDetails";
@@ -30,9 +30,16 @@ export const BillingTeamDetails = () => {
     [billingTeams, billingId]
   );
 
-  const userDetailsOfSelectedBillingTeam = useSelector(
-    getBillingTeamMemberById(billingId, user?.details?.profile?.uid)
-  );
+  // Derived from the billing team doc itself, not from the fetched member profiles, so that a
+  // failed `billing-getMembersProfile` call can't drop a licensed member into the read-only view.
+  const isCurrentTeamMember = useMemo(() => {
+    const uid = user?.details?.profile?.uid;
+    if (!uid) {
+      return false;
+    }
+    const currentBillingTeam = billingTeams?.find((billingTeam) => billingTeam?.id === billingId);
+    return Boolean(currentBillingTeam?.members?.[uid]);
+  }, [billingTeams, billingId, user?.details?.profile?.uid]);
 
   useEffect(() => {
     if (user.loggedIn && billingId && joinRequestAction && userId) {
@@ -64,7 +71,7 @@ export const BillingTeamDetails = () => {
         userId={userId}
         requestAction={joinRequestAction}
       />
-      {hasAccessToCurrentTeam || userDetailsOfSelectedBillingTeam ? (
+      {hasAccessToCurrentTeam || isCurrentTeamMember ? (
         <MyBillingTeamDetails />
       ) : (
         <OtherBillingTeamDetails />


### PR DESCRIPTION
## Problem

A user with an active subscription (RQ-5382) could not add or remove seats. Their billing page rendered the **read-only** `OtherBillingTeamDetails` view — no *Assign license* control — with the members table stuck on a spinner showing `Licensed members (0)`, despite Stripe being active and the team having 2 members.

`BillingDetails/index.tsx` chose between the two views using `getBillingTeamMemberById()`, which reads `state.billing.billingTeamMembers` — a map populated **only** after the `billing-getMembersProfile` callable resolves:

```ts
const userDetailsOfSelectedBillingTeam = useSelector(
  getBillingTeamMemberById(billingId, user?.details?.profile?.uid)
);
...
{hasAccessToCurrentTeam || userDetailsOfSelectedBillingTeam ? <MyBillingTeamDetails /> : <OtherBillingTeamDetails />}
```

Every failure mode on that path is swallowed:

- `backend/billing/index.ts:49-51` catches a rejected callable and returns `undefined` (only a `Logger.log`, no Sentry)
- `useBillingTeamsListener.ts:30` dispatches only on a truthy value

So a single failed call leaves `billingTeamMembers[billingId]` permanently `undefined`, which drives **both** the view branch and the table's `loading={!billingTeamMembers}`. One transient fetch failure = a licensed member locked out of their own billing team, with no error surfaced anywhere.

## Fix

Derive membership from `availableBillingTeams`, which comes straight from the Firestore `onSnapshot` in `useBillingTeamsListener.ts:48` and does not depend on the callable:

```ts
const isCurrentTeamMember = useMemo(() => {
  const uid = user?.details?.profile?.uid;
  if (!uid) {
    return false;
  }
  const currentBillingTeam = billingTeams?.find((billingTeam) => billingTeam?.id === billingId);
  return Boolean(currentBillingTeam?.members?.[uid]);
}, [billingTeams, billingId, user?.details?.profile?.uid]);
```

This is the same source `BillingTeamsSidebar:18` already uses to split *"My billing"* from *"Other billing teams"* — which is exactly why the reported team appeared correctly under **My billing** in the sidebar while the main pane showed read-only. The two now agree.

## Why this is safe

- **Strictly weaker than the old condition.** The profile map only ever contains uids drawn from `billingTeamData.members` (`getBillingTeamMembers.ts:60-62`), so `members[uid]` truthy cannot be `false` where the old check was `true`. No regression path.
- **`currentBillingTeam` is always found when `billingId` is set** — the `isBillingTeamDetailsViewable` guard returns the error `Result` first if the team isn't in `billingTeams`.
- **Null-safe**, unlike the sidebar's `uid in team.members`, which throws when `members` is undefined.
- `hasAccessToCurrentTeam` is left in place. It's effectively dead for normal users (`fetchBillingTeam.ts:17-19` early-returns for everyone except `requestly.extension@gmail.com`), but changing that is out of scope here.

## Scope

This restores license management for affected users regardless of *why* the callable fails. It does **not** fix the members table still spinning on a failed fetch, and it does not diagnose the client-side cause of the original failure. Both tracked separately:

- add `Sentry.captureException` at `backend/billing/index.ts:49` — a week-old production block produced zero telemetry
- track per-team fetch status (`idle | loading | error`) in the billing slice instead of inferring `loading` from `undefined`

## Testing

⚠️ **Not type-checked or built.** `node_modules` is not installed at the repo root or in `app/`, so no compiler was available locally. The change is hand-reviewed only — please confirm CI is green before merging.

There is no existing test coverage in `features/settings/components/BillingTeam`.

Manual check: open a billing team you hold a license for and confirm `MyBillingTeamDetails` renders with *Assign license* available, including with `billing-getMembersProfile` forced to fail (block it in DevTools) — the previous behaviour was to fall back to read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
