### PR TITLE
feat(banner): GrowthBook-driven legacy auth migration banner (RQ-5181)

### DIFF
--- a/app/src/componentsV2/AppNotificationBanner/banner.types.ts
+++ b/app/src/componentsV2/AppNotificationBanner/banner.types.ts
@@ -21,6 +21,7 @@ export enum BANNER_ACTIONS {
   REDIRECT_TO_CHROME_STORE_REVIEWS = "redirect_to_chrome_store_reviews",
   REDIRECT_TO_LINKEDIN_FORM = "redirect_to_linkedin_form",
   REDIRECT_TO_NOTION_PAGE = "redirect_to_notion_page",
+  MERGE_BSTACK_ACCOUNT = "merge_bstack_account",
 }
 
 export enum BANNER_ID {
@@ -32,6 +33,7 @@ export enum BANNER_ID {
   BILLING_TEAM_PLAN_REMINDER = "billing_team_plan_reminder",
   CHROME_STORE_REVIEWS = "chrome_store_reviews",
   SHARE_ON_LINKEDIN = "share_on_linkedin",
+  LOGIN_MIGRATION = "login_migration",
 }
 
 export interface Banner {

--- a/app/src/componentsV2/AppNotificationBanner/hooks/useBannerAction.ts
+++ b/app/src/componentsV2/AppNotificationBanner/hooks/useBannerAction.ts
@@ -9,6 +9,10 @@ import { httpsCallable, getFunctions } from "firebase/functions";
 import { toast } from "utils/Toast";
 import { trackCheckoutFailedEvent, trackCheckoutInitiated } from "modules/analytics/events/misc/business/checkout";
 import STORAGE from "config/constants/sub/storage";
+import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
+import { getAppMode } from "store/selectors";
+import { setRedirectMetadata } from "features/onboarding/utils";
+import { SOURCE } from "modules/analytics/events/common/constants";
 
 export const useBannerAction = (
   actions: BANNER_ACTIONS[],
@@ -16,6 +20,7 @@ export const useBannerAction = (
 ): BannerActionConfig[] => {
   const dispatch = useDispatch();
   const user = useSelector(getUserAuthDetails);
+  const appMode = useSelector(getAppMode);
   const firebaseFunction = getFunctions();
 
   const actionMap: Record<BANNER_ACTIONS, BannerActionConfig> = useMemo(
@@ -69,6 +74,30 @@ export const useBannerAction = (
           redirectToUrl(LINKS.NOTION_PAGE_FOR_PROMOTION, true);
         },
       },
+      [BANNER_ACTIONS.MERGE_BSTACK_ACCOUNT]: {
+        label: "Link BrowserStack account",
+        type: "primary",
+        onClick: () => {
+          // Brings a web user back to the page they started from. LoginHandler reads and clears
+          // this after the token exchange. Harmless on desktop, where the OAuth flow runs in a
+          // different browser and nothing reads it back.
+          setRedirectMetadata({
+            source: SOURCE.AUTH_MIGRATION_BANNER,
+            redirectURL: window.location.href,
+          });
+
+          if (appMode === GLOBAL_CONSTANTS.APP_MODES.DESKTOP) {
+            // redirectToUrl is window.open(url, "_self"), which would navigate the whole Electron
+            // window away from the app. Hand the URL to the system browser instead.
+            window.RQ?.DESKTOP?.SERVICES?.IPC?.invokeEventInBG("open-external-link", {
+              link: LINKS.OAUTH_REDIRECT_URL,
+            });
+            return;
+          }
+
+          redirectToUrl(LINKS.OAUTH_REDIRECT_URL);
+        },
+      },
       [BANNER_ACTIONS.REDIRECT_TO_LINKEDIN_FORM]: {
         label: "Share Now",
         type: "primary",
@@ -120,7 +149,7 @@ export const useBannerAction = (
         },
       },
     }),
-    [dispatch, firebaseFunction, user?.details?.planDetails, setIsRequestAccessModalOpen]
+    [dispatch, firebaseFunction, user?.details?.planDetails, setIsRequestAccessModalOpen, appMode]
   );
 
   return actions.map((action) => actionMap[action]).filter(Boolean);

--- a/app/src/componentsV2/AppNotificationBanner/hooks/useBannerAction.ts
+++ b/app/src/componentsV2/AppNotificationBanner/hooks/useBannerAction.ts
@@ -75,7 +75,7 @@ export const useBannerAction = (
         },
       },
       [BANNER_ACTIONS.MERGE_BSTACK_ACCOUNT]: {
-        label: "Link BrowserStack account",
+        label: "Sign in",
         type: "primary",
         onClick: () => {
           // Brings a web user back to the page they started from. LoginHandler reads and clears

--- a/app/src/componentsV2/AppNotificationBanner/hooks/useBannerVisibility.ts
+++ b/app/src/componentsV2/AppNotificationBanner/hooks/useBannerVisibility.ts
@@ -6,12 +6,13 @@ import { PRICING } from "features/pricing/constants/pricing";
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
 import { getAvailableBillingTeams } from "store/features/billing/selectors";
 import { useFeatureValue } from "@growthbook/growthbook-react";
-import { getAppNotificationBannerDismissTs } from "store/selectors";
+import { getAppNotificationBannerDismissTs, getUserBrowserstackId } from "store/selectors";
 
 export const useBannerVisibility = (bannerId: string): boolean => {
   const user = useSelector(getUserAuthDetails);
   const billingTeams = useSelector(getAvailableBillingTeams);
   const lastDismissTs = useSelector(getAppNotificationBannerDismissTs);
+  const browserstackId = useSelector(getUserBrowserstackId);
   const allBanners = useFeatureValue("app_banner", []);
   const newBanners = useMemo(() => allBanners.filter((banner: any) => banner.createdTs > (lastDismissTs || 0)), [
     allBanners,
@@ -63,8 +64,14 @@ export const useBannerVisibility = (bannerId: string): boolean => {
         return isTeamOwner;
       }
 
+      case BANNER_ID.LOGIN_MIGRATION:
+        // `undefined` means the user doc has not been read yet, `null` means it was read and the
+        // user has no BrowserStack account. Only the second should show the banner, otherwise an
+        // already-merged user sees it flash at every cold start.
+        return Boolean(user?.loggedIn) && browserstackId === null;
+
       default:
         return true;
     }
-  }, [bannerId, user, billingTeams, newBanners]);
+  }, [bannerId, user, billingTeams, newBanners, browserstackId]);
 };

--- a/app/src/componentsV2/AppNotificationBanner/hooks/useRenderBannerText.ts
+++ b/app/src/componentsV2/AppNotificationBanner/hooks/useRenderBannerText.ts
@@ -4,6 +4,7 @@ import { getCompanyNameFromEmail, getPrettyPlanName } from "utils/FormattingHelp
 import { isCompanyEmail } from "utils/mailCheckerUtils";
 import { Banner, BANNER_ID } from "../banner.types";
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
+import { interpolateBannerText } from "../utils/interpolateBannerText";
 
 export const useRenderBannerText = (banner: Banner): string => {
   const user = useSelector(getUserAuthDetails);
@@ -15,6 +16,8 @@ export const useRenderBannerText = (banner: Banner): string => {
   const planName = useMemo(() => getPrettyPlanName(user?.details?.planDetails?.planName), [
     user?.details?.planDetails?.planName,
   ]);
+
+  const email = user?.details?.profile?.email || "";
 
   switch (banner.id) {
     case BANNER_ID.COMMERCIAL_LICENSE:
@@ -30,6 +33,6 @@ export const useRenderBannerText = (banner: Banner): string => {
       return `You're on the ${planName} Monthly plan. Switch to the annual plan and save over 40% on your annual spends with our New Year Deal.`;
 
     default:
-      return banner.text;
+      return interpolateBannerText(banner.text, { email });
   }
 };

--- a/app/src/componentsV2/AppNotificationBanner/utils/interpolateBannerText.test.ts
+++ b/app/src/componentsV2/AppNotificationBanner/utils/interpolateBannerText.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+
+import { interpolateBannerText } from "./interpolateBannerText";
+
+describe("interpolateBannerText", () => {
+  it("substitutes a single placeholder", () => {
+    expect(interpolateBannerText("Link {{email}} now", { email: "jane@acme.com" })).toBe("Link jane@acme.com now");
+  });
+
+  it("substitutes the same placeholder more than once", () => {
+    expect(interpolateBannerText("{{email}} and {{email}}", { email: "jane@acme.com" })).toBe(
+      "jane@acme.com and jane@acme.com"
+    );
+  });
+
+  it("tolerates whitespace inside the braces", () => {
+    expect(interpolateBannerText("Link {{ email }} now", { email: "jane@acme.com" })).toBe("Link jane@acme.com now");
+  });
+
+  it("leaves an unknown placeholder as literal text", () => {
+    expect(interpolateBannerText("Hello {{name}}", { email: "jane@acme.com" })).toBe("Hello {{name}}");
+  });
+
+  it("leaves the placeholder alone when the value is an empty string", () => {
+    expect(interpolateBannerText("Link {{email}} now", { email: "" })).toBe("Link {{email}} now");
+  });
+
+  it("treats replacement patterns in the value as literal characters", () => {
+    expect(interpolateBannerText("Link {{email}}", { email: "a$&b@acme.com" })).toBe("Link a$&b@acme.com");
+  });
+
+  it("returns the text unchanged when it holds no placeholder", () => {
+    expect(interpolateBannerText("Nothing to replace", { email: "jane@acme.com" })).toBe("Nothing to replace");
+  });
+
+  it("returns the input unchanged when it is empty", () => {
+    expect(interpolateBannerText("", { email: "jane@acme.com" })).toBe("");
+  });
+});

--- a/app/src/componentsV2/AppNotificationBanner/utils/interpolateBannerText.ts
+++ b/app/src/componentsV2/AppNotificationBanner/utils/interpolateBannerText.ts
@@ -1,0 +1,15 @@
+const PLACEHOLDER_PATTERN = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
+
+/**
+ * Substitutes {{key}} placeholders in GrowthBook-authored banner copy.
+ * An unknown or empty value leaves the placeholder in place on purpose, so a typo in the
+ * GrowthBook entry reads as an obvious "{{foo}}" rather than as "undefined".
+ */
+export const interpolateBannerText = (text: string, values: Record<string, string>): string => {
+  if (!text) {
+    return text;
+  }
+
+  // The replacer must stay a function — it keeps "$&" and friends inside the value literal.
+  return text.replace(PLACEHOLDER_PATTERN, (placeholder, key) => values[key] || placeholder);
+};

--- a/app/src/hooks/DbListenerInit/DBListeners.js
+++ b/app/src/hooks/DbListenerInit/DBListeners.js
@@ -4,6 +4,7 @@ import { getAppMode, getAuthInitialization } from "../../store/selectors";
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
 import syncingNodeListener from "./syncingNodeListener";
 import userNodeListener from "./userNodeListener";
+import userDocListener from "./userDocListener";
 import { globalActions } from "store/slices/global/slice";
 import { isArray } from "lodash";
 import { useHasChanged } from "hooks/useHasChanged";
@@ -21,6 +22,7 @@ const DBListeners = () => {
   const hasAuthInitialized = useSelector(getAuthInitialization);
 
   let unsubscribeUserNodeRef = useRef(null);
+  let unsubscribeUserDocRef = useRef(null);
   window.unsubscribeSyncingNodeRef = useRef(null);
 
   const hasAuthStateChanged = useHasChanged(user?.loggedIn);
@@ -28,8 +30,10 @@ const DBListeners = () => {
   // Listens to /users/{id} changes
   useEffect(() => {
     if (unsubscribeUserNodeRef.current) unsubscribeUserNodeRef.current(); // Unsubscribe existing user node listener before creating a new one
+    if (unsubscribeUserDocRef.current) unsubscribeUserDocRef.current();
     if (user?.loggedIn) {
       unsubscribeUserNodeRef.current = userNodeListener(dispatch, user?.details?.profile.uid, appMode);
+      unsubscribeUserDocRef.current = userDocListener(user?.details?.profile.uid);
       /* CAN BE MOVED TO SEPARATE USE EFFECT AND SHOULD HAVE AN UNSUBSCRIBER TOO, will be useful when actually implementing premium */
       userSubscriptionDocListener(dispatch, user?.details?.profile.uid);
     }

--- a/app/src/hooks/DbListenerInit/userDocListener.js
+++ b/app/src/hooks/DbListenerInit/userDocListener.js
@@ -1,0 +1,40 @@
+import { doc, getFirestore, onSnapshot } from "firebase/firestore";
+import firebaseApp from "../../firebase";
+import APP_CONSTANTS from "config/constants";
+import { submitAttrUtil } from "utils/AnalyticsUtils";
+import Logger from "lib/logger";
+
+/**
+ * Keeps the GrowthBook attribute `browserstack_id` in step with the Firestore user doc.
+ * The BrowserStack merge writes `browserstackId` from a different browser when the app runs on
+ * desktop, and AuthHandler only reads it once from onAuthStateChanged — so without this
+ * subscription the desktop app would not notice the merge until the next restart.
+ *
+ * @returns the unsubscribe function, or null when no listener was attached.
+ */
+const userDocListener = (uid) => {
+  if (!uid) {
+    return null;
+  }
+
+  try {
+    const db = getFirestore(firebaseApp);
+    const userDocRef = doc(db, "users", uid);
+
+    return onSnapshot(
+      userDocRef,
+      (docSnapshot) => {
+        const userData = docSnapshot.exists() ? docSnapshot.data() : null;
+        submitAttrUtil(APP_CONSTANTS.GA_EVENTS.ATTR.BROWSERSTACK_ID, userData?.browserstackId ?? null);
+      },
+      (err) => {
+        Logger.log(`[userDocListener] Encountered error: ${err}`);
+      }
+    );
+  } catch (err) {
+    Logger.log(`[userDocListener] Failed to attach listener: ${err}`);
+    return null;
+  }
+};
+
+export default userDocListener;

--- a/app/src/modules/analytics/events/common/constants.js
+++ b/app/src/modules/analytics/events/common/constants.js
@@ -135,6 +135,7 @@ export const SOURCE = {
   SHARED_LIST_SCREEN: "shared_list_screen",
   EXTENSION_ONBOARDING: "extension_onboarding",
   DESKTOP_ONBOARDING: "desktop_onboarding",
+  AUTH_MIGRATION_BANNER: "auth_migration_banner",
   PRICING_TABLE: "pricing_table",
   TEAM_WORKSPACE_BAD_INVITE_SCREEN: "team_workspace_bad_invite_screen",
   WORKSPACE_DROPDOWN: "workspace_dropdown",

--- a/app/src/store/selectors.js
+++ b/app/src/store/selectors.js
@@ -215,6 +215,12 @@ export const getUserAttributes = (state) => {
   return getGlobalState(state)["userAttributes"];
 };
 
+// Returns a primitive on purpose — consuming the whole `userAttributes` object in a component
+// re-renders on every attribute write, as the getUserRulesCount note below records.
+export const getUserBrowserstackId = (state) => {
+  return getUserAttributes(state)?.browserstack_id;
+};
+
 // Had to make a separate selector, since consuming
 // "userAttributes" directly in <RulesListContainer/> component goes into infinite re-renders
 // TODO: fix above


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: [RQ-5181](https://browserstack.atlassian.net/browse/RQ-5181)

## 📜 Summary of changes:

Adds the code the GrowthBook-driven legacy auth migration banner needs: a new `merge_bstack_account` action whose CTA opens `${VITE_BACKEND_BASE_URL}/oauth/authorize` — in the current tab on web, and via the `open-external-link` IPC channel on desktop so the Electron window never navigates away. Banner copy gains generic `{{key}}` interpolation so the text can name the signed-in user's email. A new Firestore `users/{uid}` listener pushes `browserstackId` into the GrowthBook attributes live, which is what makes the banner clear itself on desktop — the merge completes in a different browser there, and `AuthHandler` only reads that field once from `onAuthStateChanged`, so without this the banner would persist until the next app restart. A `useBannerVisibility` guard distinguishes `undefined` (user doc not read yet) from `null` (read, no BrowserStack account) so already-merged users never see it flash at cold start.

No backend change, no new dependency, and no new analytics plumbing — the three existing banner events already carry `bannerId` and `cta`, and `trackEvent` stamps `rq_app_mode` on each one so web and desktop split without extra work.

## 🎥 Demo Video:

**Video/Demo:** Not yet — the banner does not render until the GrowthBook `app_banner` entry exists (see test instructions). Will attach once it is configured on a preview build.

## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [x] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [x] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

Notes on the unchecked boxes: no extension code is touched (see "Not in this PR" below), and there is no existing doc page for the banner system.

## 🧪 Test instructions:

**Unit:** `cd app && npm test` — 37 pass, 8 of them new for `interpolateBannerText`.

**UI:** the banner is config-gated, so add this entry to the GrowthBook `app_banner` feature with `createdTs` set to the publish time:

```json
{
  "id": "login_migration",
  "text": "Requestly authentication is moving to BrowserStack. Link **{{email}}** to your BrowserStack account to keep using Requestly.",
  "createdTs": 0,
  "isDismissable": false,
  "actions": ["merge_bstack_account"],
  "type": "warning"
}
```

Targeting: `{ "email": { "$exists": true, "$ne": "" }, "browserstack_id": null }`, plus the SSO domain exclusions.

Three things that will bite if missed:

- `actions` must be `merge_bstack_account`. `request_access` is an existing id that opens the billing-team modal.
- Use a current `createdTs`. A past timestamp lets an earlier dismissal hide the banner.
- Leave `backgroundColor` and `cta` out. `.app-banner__warning` sets the colour with `!important`, and no component reads `cta`.

| # | Surface | State | Expected |
| --- | --- | --- | --- |
| 1 | Web | `browserstackId` absent | Banner shows, own email in the text, no close button |
| 2 | Web | CTA clicked | Current tab goes to the OAuth URL |
| 3 | Web | Merge finished | Returns to the starting page, banner gone |
| 4 | Desktop | `browserstackId` absent | Banner shows, app window does not navigate on click |
| 5 | Desktop | CTA clicked | System browser opens the OAuth URL |
| 6 | Desktop | Merge finished in that browser | Banner disappears with no restart |
| 7 | Both | `browserstackId` already set | Banner never appears, including at cold start |
| 8 | Both | Signed out | Banner never appears |

Test 6 exercises the Firestore listener. Test 7 exercises the cold-start guard.

## 🔗 Other references:

**Not in this PR**, each worth its own ticket:

- **Browser extension popup.** RQ-5181's description asks for it. It is a separate React app (`browser-extension/common/src/popup/`) that never mounts `DashboardLayout`, so no change here can reach it.
- **Dismiss-timestamp defect.** `AppNotificationBanner/index.tsx:20` filters on one global `lastDismissTs`, so dismissing a newer banner also hides older ones — including non-dismissable ones like this one.
- **Wireframe steps 2, 4a, 4b** (confirmation modal, one-time success banner, different-account popup). Dropped by product call: a mismatched BrowserStack sign-in means a different user, and the persistent banner is the only signal.

**On type-check:** `tsc --noEmit` reports 1348 pre-existing errors on this repo, so it is not a usable gate. Diffing errors before and after this branch (ignoring line shifts) leaves one new entry: `Cannot find module '@requestly/requestly-core'` in `useBannerAction.ts`. Every `.ts` file in the repo importing that package reports the same thing, so this follows the established pattern rather than introducing a new problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RQ-5181]: https://browserstack.atlassian.net/browse/RQ-5181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ