### PR TITLE
chore(app): bump app version to 26.8.14

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestly/app",
-  "version": "25.8.21",
+  "version": "26.8.14",
   "private": true,
   "description": "Requestly - Lightweight Proxy to Intercept & Modify HTTP(s) requests",
   "main": "index.js",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- n/a -->

## 📜 Summary of changes:

Bumps `app/package.json` from `25.8.21` to `26.8.14`, following the existing `YY.M.DD` convention. This value feeds `VITE_REACT_APP_VERSION` via `.env` (`VITE_REACT_APP_VERSION=$npm_package_version`), which `AppUpdateNotifier` compares against `_appData/latestAppVersion` and `_appData/breakingAppVersion` in RTDB to decide whether to show the update toast or force a silent reload. No other change.

## 🎥 Demo Video:

**Video/Demo:** Not applicable — a version constant change with no user-facing UI of its own.

## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

Unchecked boxes are not applicable: no UI, no extension code, no new behaviour to test, and a version constant is not worth a unit test.

## 🧪 Test instructions:

After deploy, confirm the shipped bundle reports the new version — `AppUpdateNotifier.tsx:59` reads `process.env.VITE_REACT_APP_VERSION`.

Then the RTDB `_appData` behaviour follows from it:

| `_appData` value | Effect on a `26.8.14` client |
| --- | --- |
| `breakingAppVersion` > `26.8.14` | Silent forced reload with `?forceRefresh=true` |
| `breakingAppVersion` ≤ `26.8.14` | Nothing — the comparison is strictly less than |
| `latestAppVersion` > `26.8.14` | Dismissible "New update available" toast |

Note that any client still on `25.8.21` will be force-reloaded by any `breakingAppVersion` above that, so set the value deliberately.

## 🔗 Other references:

Separate from #109 (RQ-5181 migration banner) on purpose — this is an independent release chore and should not be gated on that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
