### PR TITLE
fix(security): RQ-3841 read the auth token from the URL fragment

### DIFF
--- a/app/src/components/authentication/LoginHandler/index.tsx
+++ b/app/src/components/authentication/LoginHandler/index.tsx
@@ -24,6 +24,25 @@ const ARGUMENTS = {
   ACCESS_TOKEN: "accessToken",
 };
 
+/*
+ RQ-3841: remove the token from the visible URL without adding a history entry. Strips
+ the whole fragment (it only ever carries the token) and any legacy accessToken still
+ arriving in the query string, while preserving every other param the flow reads.
+*/
+const clearAccessTokenFromUrl = () => {
+  try {
+    const url = new URL(window.location.href);
+    if (!url.hash && !url.searchParams.has(ARGUMENTS.ACCESS_TOKEN)) {
+      return;
+    }
+    url.hash = "";
+    url.searchParams.delete(ARGUMENTS.ACCESS_TOKEN);
+    window.history.replaceState(null, "", `${url.pathname}${url.search}`);
+  } catch (error) {
+    Logger.log("[LoginHandler-clearAccessTokenFromUrl] catch", { error });
+  }
+};
+
 const LoginHandler: React.FC = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -36,6 +55,21 @@ const LoginHandler: React.FC = () => {
 
   const params = useMemo(() => new URLSearchParams(window.location.search), []);
   const isNewUser = params.get("isNewUser") === "true";
+
+  /*
+   RQ-3841: the custom token arrives in the URL fragment, which browsers never send to a
+   server -- so it stays out of Referer headers (this page loads Amplitude / Sentry /
+   GrowthBook), out of GCP + CDN access logs, and out of anything else recording URLs.
+   The query-string read is a compatibility fallback: requestly-cloud only moves the
+   token to the fragment in a later deploy, and older/cached callback URLs may still
+   carry it in the query. Safe to drop once that has shipped everywhere.
+   Read once on mount -- the token is consumed immediately below, and clearAccessTokenFromUrl
+   rewrites the address bar afterwards.
+  */
+  const accessToken = useMemo(() => {
+    const hash = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : window.location.hash;
+    return new URLSearchParams(hash).get(ARGUMENTS.ACCESS_TOKEN) ?? params.get(ARGUMENTS.ACCESS_TOKEN);
+  }, [params]);
 
   const postLoginDesktopAppRedirect = useCallback(() => {
     let desktopAuthParams = getDesktopAppAuthParams();
@@ -125,7 +159,6 @@ const LoginHandler: React.FC = () => {
     }
 
     isAuthenticationAttempted.current = true;
-    const accessToken = params.get(ARGUMENTS.ACCESS_TOKEN);
     if (!accessToken) {
       // this route is only meant to be accessed programmatically
       redirectToHome(appMode, navigate);
@@ -144,6 +177,9 @@ const LoginHandler: React.FC = () => {
     }
 
     const redirectMetadata = getRedirectMetadata();
+    // RQ-3841: token is in hand -- drop it from the address bar so it is not left in
+    // the visible URL to be copied, bookmarked, or read by an extension.
+    clearAccessTokenFromUrl();
     const auth = getAuth(firebaseApp);
     signInWithCustomToken(auth, accessToken)
       .then((result) => {
@@ -183,7 +219,7 @@ const LoginHandler: React.FC = () => {
         // todo: setup error monitoring
         setLoginComplete(true);
       });
-  }, [params, user.loggedIn, loginComplete, navigate, appMode, dispatch, isNewUser]);
+  }, [accessToken, params, user.loggedIn, loginComplete, navigate, appMode, dispatch, isNewUser]);
 
   return <PageLoader message="Logging in..." />;
 };


### PR DESCRIPTION
Client half of [RQ-3841](https://browserstack.atlassian.net/browse/RQ-3841). **Merge and deploy this before** the requestly-cloud half.

## Why

`/oauth/callback` currently redirects to `app.requestly.io/?accessToken=<firebase custom token>`. A token in the query string is recorded in:

- browser history
- the `Referer` header sent to every third-party script this page loads (Amplitude, Sentry, GrowthBook)
- GCP / Firebase HTTP access logs, and any CDN or proxy in between

The token exchanges for a Firebase refresh token, so one leaked log line becomes durable account access. Moving it to the **fragment** fixes this: browsers never send a fragment to a server.

## Ordering — this must land first

The server change switches the token to the fragment. A client that only reads `window.location.search` would then find no token and **every OAuth login would break**.

This PR makes the client accept **either** location, so the two repos can deploy in any order:

```ts
new URLSearchParams(hash).get("accessToken") ?? params.get("accessToken")
```

The query-string fallback also covers cached / in-flight callback URLs. It can be deleted once the server change is live in beta and production.

## Changes

- **Read the fragment first, fall back to the query string.** Captured in a `useMemo` on mount, so clearing the URL later cannot null it out mid-flow.
- **`clearAccessTokenFromUrl()`** — once the token is captured, rewrite the address bar with `history.replaceState` (no new history entry) so the credential is not left visible to be copied, bookmarked, or read by an extension. Strips the whole fragment plus any legacy query `accessToken`, while preserving every other param the flow reads (`isNewUser`, `redirectURL`).

## Verification

- **Parses clean** — `ts.transpileModule`, 0 syntax diagnostics. I could not run a full `tsc`/lint: I worked from a sparse shallow clone without the app's dependencies installed, so **please let CI be the real check here.**
- **Fragment round-trip tested** with a token containing `+`, `/` and `=`. `URLSearchParams` percent-encodes on write and decodes on read; naive string concatenation would corrupt such a token.
- **Desktop flow unaffected** — `getDesktopAppAuthParams()` reads `localStorage`, not the URL, so clearing the address bar cannot disturb `auth_mode` / `ot-auth-code`.

## Reviewer notes

1. The `useEffect` dependency array gained `accessToken`. Behaviour is unchanged in practice (`params` is `[]`-memoized, so `accessToken` is stable for the component's life), but worth a look.
2. I'd like confirmation that no other surface reads `?accessToken` from this redirect. I found only this component plus `AuthPage.js` / `FirebaseActions.js` / `AuthHandler.ts` referencing `signInWithCustomToken`, and none of the others parse the URL — but I was searching a sparse checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RQ-3841]: https://browserstack.atlassian.net/browse/RQ-3841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ