### PR TITLE
fix(security): RQ-3893 stop reading and writing appSumoCodes from the browser

### DIFF
--- a/app/src/components/landing/Appsumo/Appsumo.tsx
+++ b/app/src/components/landing/Appsumo/Appsumo.tsx
@@ -10,8 +10,6 @@ import { FiXCircle } from "@react-icons/all-files/fi/FiXCircle";
 import { useNavigate } from "react-router-dom";
 import { redirectToRoot } from "utils/RedirectionUtils";
 import AppSumoWorkspaceDropdown from "components/landing/Appsumo/AppSumoWorkspaceDropdown/AppSumoWorkspaceDropdown";
-import { doc, getDoc, getFirestore, writeBatch } from "firebase/firestore";
-import firebaseApp from "../../../firebase";
 import { toast } from "utils/Toast";
 import { isEmailValid } from "utils/FormattingHelper";
 import { useDebounce } from "hooks/useDebounce";
@@ -48,8 +46,6 @@ const AppSumoModal: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isUpdatingSubscription, setIsUpdatingSubscription] = useState(false);
   const [showMaxCodesExeceededError, setShowMaxCodesExeceededError] = useState(false);
-
-  const db = getFirestore(firebaseApp);
 
   const addAppSumoCodeInput = () => {
     if (appsumoCodes.length >= 10) {
@@ -96,34 +92,46 @@ const AppSumoModal: React.FC = () => {
         return;
       }
 
-      const docRef = doc(db, "appSumoCodes", enteredCode);
-      const docSnap = await getDoc(docRef);
+      // RQ-3893: the server validates now. This used to read `appSumoCodes/{code}`
+      // straight from the browser, which forced the Firestore rules to let every
+      // authenticated user read the collection — and a wildcard read also grants
+      // `list`, so the entire licence table was enumerable. The callable returns a
+      // verdict only for the code the user typed.
+      const validateAppSumoCodes = httpsCallable<
+        { codes: string[] },
+        { success: boolean; message?: string; checks?: { code: string; valid: boolean; reason?: string }[] }
+      >(getFunctions(), "subscription-validateAppSumoCodes");
 
-      if (!docSnap.exists()) {
-        updateAppSumoCode(index, "error", "Invalid code");
+      try {
+        const response = await validateAppSumoCodes({ codes: [enteredCode] });
+        const verdict = response?.data?.checks?.find((check) => check.code === enteredCode);
+
+        if (!response?.data?.success || !verdict) {
+          updateAppSumoCode(index, "error", "Could not verify this code, please try again");
+          updateAppSumoCode(index, "verified", false);
+          return;
+        }
+
+        if (!verdict.valid) {
+          updateAppSumoCode(
+            index,
+            "error",
+            verdict.reason === "already_redeemed" ? "Code already redeemed" : "Invalid code"
+          );
+          updateAppSumoCode(index, "verified", false);
+          return;
+        }
+      } catch {
+        updateAppSumoCode(index, "error", "Could not verify this code, please try again");
         updateAppSumoCode(index, "verified", false);
         return;
       }
 
-      if (docSnap.data()?.redeemed) {
-        updateAppSumoCode(index, "error", "Code already redeemed");
-        updateAppSumoCode(index, "verified", false);
-        return;
-      }
       updateAppSumoCode(index, "error", "");
       updateAppSumoCode(index, "verified", true);
     },
-    [db, appsumoCodes]
+    [appsumoCodes]
   );
-
-  const redeemSubmittedCodes = useCallback(async () => {
-    const batch = writeBatch(db);
-    appsumoCodes.forEach((code) => {
-      const docRef = doc(db, "appSumoCodes", code.code);
-      batch.update(docRef, { redeemed: true });
-    });
-    await batch.commit();
-  }, [db, appsumoCodes]);
 
   const createNewWorkspaceForAppSumo = useCallback(async () => {
     setIsLoading(true);
@@ -181,8 +189,16 @@ const AppSumoModal: React.FC = () => {
         .then((response) => {
           if (!response?.data?.success && response?.data?.error === "max_limit_reached") {
             setShowMaxCodesExeceededError(true);
+          } else if (!response?.data?.success) {
+            // RQ-3893: previously any unsuccessful response that was not
+            // `max_limit_reached` fell into the success branch below and showed an
+            // "unlocked" toast for a redemption that never happened.
+            toast.error(response?.data?.message || "Could not redeem these codes, please try again", 10);
           } else {
-            redeemSubmittedCodes();
+            // RQ-3893: the codes are marked redeemed by the callable, inside the same
+            // transaction that grants the tier. The browser used to do it afterwards
+            // in an un-awaited batch write, so a failure there was silent and left the
+            // codes reusable.
             trackAppsumoCodeRedeemed(appsumoCodes.length);
             toast.success(
               `Lifetime access to SessionBook Plus unlocked for ${
@@ -198,13 +214,14 @@ const AppSumoModal: React.FC = () => {
         });
     } catch (error) {
       console.error("from appsumo", error);
+      setIsUpdatingSubscription(false);
+      toast.error("Could not redeem these codes, please try again", 10);
     }
   }, [
     createNewWorkspaceForAppSumo,
     appsumoCodes,
     emailValidationError,
     isAllCodeCheckPassed,
-    redeemSubmittedCodes,
     workspaceToUpgrade?.id,
     navigate,
   ]);


### PR DESCRIPTION
Client half of [RQ-3893](https://browserstack.atlassian.net/browse/RQ-3893). **Prerequisite for** requestly/requestly-cloud#880 — those Firestore rules cannot deploy until this ships.

## Why this is needed

requestly-cloud#880 closes an escalation path: the `appSumoCodes` Firestore rules granted every authenticated user `read, update`, so any account could enumerate licence codes and clear `redeemed` on a paying customer's. The fix locks the collection to `if false`.

This component is the reason those permissions existed. It performed both halves of redemption in the browser:

```ts
// Appsumo.tsx:99  — validate
const docSnap = await getDoc(doc(db, "appSumoCodes", enteredCode));
// Appsumo.tsx:122 — consume
batch.update(docRef, { redeemed: true });
```

Deploying the rules against this code would have broken redemption outright:

1. The read fails, so `verified` is never set, so `isAllCodeCheckPassed` stays false and `onSubmit` throws *"Please fill all the fields correctly"* — **nobody could redeem at all**.
2. The write fails too, and because `redeemSubmittedCodes()` was called un-awaited inside `.then()` with no `catch`, it failed **silently** — the user would see the success toast while the code stayed unredeemed and infinitely reusable.

## Changes

### Validation moves to a callable

`verifyCode` now calls `subscription-validateAppSumoCodes` (added in requestly-cloud#880) instead of reading Firestore. The callable returns a verdict only for codes the caller supplied, so it is not an enumeration oracle — the previous wildcard `allow read` also granted `list`, which is what made the whole table readable.

The user-facing messages are unchanged: *"Invalid code"* for a code that does not exist, *"Code already redeemed"* for one already used, plus a new *"Could not verify this code, please try again"* when the call itself fails (previously an exception here left the input silently unverified).

### Client-side redemption removed

`redeemSubmittedCodes()` is deleted. The server now marks codes redeemed inside the same transaction that grants the tier, which also closes the race the client version had between reading `redeemed` and setting it.

### Failed redemptions no longer report success

```diff
  if (!response?.data?.success && response?.data?.error === "max_limit_reached") {
    setShowMaxCodesExeceededError(true);
+ } else if (!response?.data?.success) {
+   toast.error(response?.data?.message || "Could not redeem these codes, please try again", 10);
  } else {
```

Any unsuccessful response that was not `max_limit_reached` previously fell into the success branch and showed *"Lifetime access … unlocked"* for a redemption that never happened. The outer `catch` now surfaces a toast as well, instead of only `console.error`.

The component no longer imports `firebase/firestore` at all.

## Not changed

The workspace picker already restricts to workspaces where the caller is an admin (`AppSumoWorkspaceDropdown`, `members[uid].role === "admin"`), so it is consistent with the new admin check on the callable. No change needed there.

## Deploy order

**Corrected 2026-08-26.** An earlier revision of this section said to deploy this PR first. That is wrong: this PR calls `subscription-validateAppSumoCodes`, so shipping it before that callable exists makes `httpsCallable` reject with `functions/not-found`, the input never verifies, and the submit button never enables — the same breakage, just from the other side.

The safe order is:

1. **Deploy the callables** from requestly/requestly-cloud#880 (`subscription-validateAppSumoCodes` and the reworked `subscription-updateTeamSubscriptionForAppSumo`). Additive — the currently-deployed client does not call them.
2. **Deploy this PR.** The callable it depends on now exists.
3. **Deploy the Firestore rules** from requestly/requestly-cloud#880, last — once no browser touches `appSumoCodes`.

Deploying this PR before step 1, or the rules before step 2, breaks AppSumo redemption.


[RQ-3893]: https://browserstack.atlassian.net/browse/RQ-3893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ