### PR TITLE
feat(auth): load BrowserStack group/sub-group ids into the Redux user (RQ-4675)

### DIFF
--- a/app/src/backend/models/users.ts
+++ b/app/src/backend/models/users.ts
@@ -16,6 +16,8 @@ export interface User {
   signupTs: number;
   username: string;
   browserstackId?: string;
+  browserstackGroupId?: string;
+  browserstackSubGroupId?: string;
   "block-config"?: BlockConfig;
   metadata?: UserMetadata;
 }

--- a/app/src/hooks/AuthHandler.ts
+++ b/app/src/hooks/AuthHandler.ts
@@ -88,6 +88,8 @@ const AuthHandler: React.FC<{}> = () => {
           loggedIn: true,
           details: {
             organization: enterpriseDetails?.data?.enterpriseData ?? null,
+            browserstackGroupId: userData?.browserstackGroupId ?? null,
+            browserstackSubGroupId: userData?.browserstackSubGroupId ?? null,
           },
         })
       );

--- a/app/src/store/slices/global/user/types.ts
+++ b/app/src/store/slices/global/user/types.ts
@@ -39,5 +39,7 @@ export interface UserAuth {
     };
     organization?: any;
     emailType?: EmailType;
+    browserstackGroupId?: string | null;
+    browserstackSubGroupId?: string | null;
   };
 }


### PR DESCRIPTION
## What

Load the user's BrowserStack **group** and **active sub-group (team)** ids into the Redux user object (`user.details`) at login, so the analytics layer can attribute Interceptor usage per team/user (RQ-3644 / RQ-4675).

This is the **open-source client half**. It pairs with **requestly-cloud PR #883**, which (a) captures these ids onto the `users/{uid}` Firestore doc at OAuth login and (b) reads them from `user.details` in the analytics enrichment to stamp `group_id` / `sub_group_id` onto events. **Both must ship together.**

## Changes (3 files, generic user metadata only — no analytics/tracking logic here)

- `app/src/backend/models/users.ts` — add optional `browserstackGroupId` / `browserstackSubGroupId` to the user-doc model.
- `app/src/store/slices/global/user/types.ts` — add the same two optional fields to `UserAuth["details"]`.
- `app/src/hooks/AuthHandler.ts` — on login, pass the two ids from the user doc into the existing `updateUserInfo({ loggedIn, details })` dispatch.

## Rollout behavior

- Values are `null` when absent (non-SSO / logged-out / no active team) — null-safe throughout; nothing throws.
- The ids are written to the user doc only at BrowserStack-OAuth login (in requestly-cloud), so **existing users pick them up after one re-login**; new SSO logins get them immediately. `AuthHandler` reads the doc on every `onAuthStateChanged`, so once written, a normal load loads them.

## Testing

- Verified locally (Firebase emulator): seeded `users/{uid}` with the two ids → `AuthHandler` loaded them into `global.user.details` → the analytics enrichment stamped `group_id` / `sub_group_id` on `rule_created` events (confirmed via console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
